### PR TITLE
Autoselect

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "eslint-plugin-jsx-a11y": "^6.2.1",
     "eslint-plugin-react": "^7.14.2",
     "html-webpack-plugin": "^3.2.0",
-    "lint-staged": "^9.4.2",
+    "lint-staged": "^9.2.0",
     "node-sass": "^4.12.0",
     "optimize-css-assets-webpack-plugin": "^5.0.3",
     "pre-commit": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-link-group",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "A ReactJS component for rendering a grouping of clickable links. Clicking a link executes a callback function, passing it the id of the selected link",
   "main": "/dist/react-link-group.bundle.js",
   "scripts": {
@@ -64,7 +64,7 @@
     "eslint-plugin-jsx-a11y": "^6.2.1",
     "eslint-plugin-react": "^7.14.2",
     "html-webpack-plugin": "^3.2.0",
-    "lint-staged": "^9.2.0",
+    "lint-staged": "^9.4.2",
     "node-sass": "^4.12.0",
     "optimize-css-assets-webpack-plugin": "^5.0.3",
     "pre-commit": "^1.2.2",

--- a/src/LinkGroup.js
+++ b/src/LinkGroup.js
@@ -52,7 +52,7 @@ class LinkGroup extends Component {
     const theme = composeThemeFromProps(styles, this.props, {
       compose: 'Replace',
     });
-console.log(selected)
+
     const linkList = links.map((link, i) => (
       <Link
         key={link.id}

--- a/src/LinkGroup.js
+++ b/src/LinkGroup.js
@@ -52,13 +52,13 @@ class LinkGroup extends Component {
     const theme = composeThemeFromProps(styles, this.props, {
       compose: 'Replace',
     });
-
-    const linkList = links.map((link) => (
+console.log(selected)
+    const linkList = links.map((link, i) => (
       <Link
         key={link.id}
         {...this.props}
         {...link}
-        selected={link.id === selected}
+        selected={link.id === selected || (selected === undefined && i === 0)}
         selectionCallback={this.linkSelection}
       />
     ));


### PR DESCRIPTION
There is no point to have a link group with no auto select. This fix will make sure the first item in the group is selected if nothing else is selected.